### PR TITLE
fix: M2M access issue by checking instance pk before fetching related…

### DIFF
--- a/django_remote_form_helpers/forms/mixins/api_fields_handler.py
+++ b/django_remote_form_helpers/forms/mixins/api_fields_handler.py
@@ -33,12 +33,14 @@ class APIFieldsHandlerFormMixin:
 
     def initialize_api_fields(self):
         if not self.is_bound:
+            instance_pk = getattr(self.instance, 'pk', None)
+
             for field_name in self.API_FIELDS:
                 form_field = self.fields.get(field_name)
                 initial_value = self.initial.get(field_name, None)
                 
                 if isinstance(form_field, forms.ModelChoiceField):                
-                    if initial_value is None and self.instance:
+                    if initial_value is None and instance_pk:
                         initial_value = getattr(self.instance, field_name, None)
                     
                     if initial_value is not None:


### PR DESCRIPTION
The error occurs because Django requires a valid primary key (ID) to access a related field like ManyToMany before saving the instance. When trying to retrieve the relationship via getattr, Django raises an error since the instance lacks an ID at that point. To avoid this, ensure the instance is saved or has a valid primary key before attempting to access related fields. Checking self.instance.pk solves this by confirming the instance has a valid ID.